### PR TITLE
Change reference from Rdf to RDF in test/testJsonld-cpp/CMakeLists.txt

### DIFF
--- a/test/testjsonld-cpp/CMakeLists.txt
+++ b/test/testjsonld-cpp/CMakeLists.txt
@@ -32,20 +32,20 @@ add_test(NAME UnitTests_JsonLdProcessor_expand_jsonld-cpp
 
 ####
 
-add_executable(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp main.cpp test_JsonLdProcessor_toRdf.cpp testHelpers.cpp testHelpers.h)
+add_executable(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp main.cpp test_JsonLdProcessor_toRDF.cpp testHelpers.cpp testHelpers.h)
 
-target_compile_features(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp PRIVATE cxx_std_11)
-target_compile_options(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp PRIVATE ${DCD_CXX_FLAGS})
-set_target_properties(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_features(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp PRIVATE cxx_std_11)
+target_compile_options(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp PRIVATE ${DCD_CXX_FLAGS})
+set_target_properties(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp PROPERTIES CXX_EXTENSIONS OFF)
 
-target_include_directories(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp
+target_include_directories(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp
         PUBLIC
         ${PROJECT_SOURCE_DIR}/libjsonld-cpp)
 
-target_link_libraries(UnitTests_JsonLdProcessor_toRdf_jsonld-cpp jsonld-cpp Boost::filesystem gtest gmock rapidcheck_gtest)
+target_link_libraries(UnitTests_JsonLdProcessor_toRDF_jsonld-cpp jsonld-cpp Boost::filesystem gtest gmock rapidcheck_gtest)
 
-add_test(NAME UnitTests_JsonLdProcessor_toRdf_jsonld-cpp
-        COMMAND UnitTests_JsonLdProcessor_toRdf_jsonld-cpp)
+add_test(NAME UnitTests_JsonLdProcessor_toRDF_jsonld-cpp
+        COMMAND UnitTests_JsonLdProcessor_toRDF_jsonld-cpp)
 
 ####
 


### PR DESCRIPTION
Initial build failed due to case mismatch for RDF in filename defined in CMakesLists.txt file