### PR TITLE
fix issue with duplicate test counts

### DIFF
--- a/libjsonld-cpp/Context.cpp
+++ b/libjsonld-cpp/Context.cpp
@@ -764,8 +764,7 @@ void Context::createTermDefinition(
         std::string baseURL,
         bool isProtected,
         bool overrideProtected,
-        std::vector<std::string> remoteContexts,
-        bool validateScopedContext) {
+        std::vector<std::string> remoteContexts) {
 
     // Comments in this function are labelled with numbers that correspond to sections
     // from the description of the create term definition algorithm.

--- a/libjsonld-cpp/Context.h
+++ b/libjsonld-cpp/Context.h
@@ -44,9 +44,7 @@ private:
             std::string baseURL = "",
             bool isProtected = false,
             bool overrideProtected = false,
-            std::vector<std::string> remoteContexts = std::vector<std::string>(),
-            bool validateScopedContext = true
-            );
+            std::vector<std::string> remoteContexts = std::vector<std::string>());
 
     void init();
 

--- a/libjsonld-cpp/sha256.cpp
+++ b/libjsonld-cpp/sha256.cpp
@@ -147,7 +147,7 @@ std::string SHA256::final()
 
     char buf[2*SHA256::DIGEST_SIZE+1];
     buf[2*SHA256::DIGEST_SIZE] = 0;
-    for (int i = 0; i < SHA256::DIGEST_SIZE; i++)
+    for (unsigned int i = 0; i < SHA256::DIGEST_SIZE; i++)
         sprintf(buf+i*2, "%02x", digest[i]);
 
     // Reset for next run

--- a/test/implementation-report/CommandRunner.cpp
+++ b/test/implementation-report/CommandRunner.cpp
@@ -8,6 +8,7 @@ CommandRunner::CommandRunner(std::string command) : command{command}{}
 std::string CommandRunner::run()
 {
     FILE* pipe;
+    output.str("");
     // clear any error states on the stringstream
     output.clear();
     // set the stringstream position to the beginning

--- a/test/implementation-report/ConfigReader.cpp
+++ b/test/implementation-report/ConfigReader.cpp
@@ -18,7 +18,7 @@ ConfigReader::ConfigReader(std::string  filename)
 std::vector<std::vector<std::string>> ConfigReader::getTestsuites()
 {
     std::vector<std::vector<std::string>> testsuites;
-    for ( const auto s : document["testsuites"])
+    for ( const auto &s : document["testsuites"])
     {
         std::vector<std::string> ts;
         ts.push_back(s["file"]);

--- a/test/implementation-report/TestRunner.cpp
+++ b/test/implementation-report/TestRunner.cpp
@@ -106,6 +106,7 @@ bool TestRunner::next_executable()
 
     if ( executable_iterator < executables.size() )
     {
+        ss.str("");
         // clear any error states on the stringstream
         ss.clear();
         // set the stringstream position to the beginning


### PR DESCRIPTION
Thanks for the heads up on where to look, I found that a couple of stringstreams were only partially reset.  I have also fixed a couple of compiler warnings but please check that they're not part of any work in progress.

I've not managed to comprehensively test more than it's just providing more indicative numbers for the tests in manifests.  I'll continue to do that but wanted to update you as to the progress