### PR TITLE
Improve installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,8 @@ ExternalProject_Add(uriparser
 
 ExternalProject_Add(http-link-header-cpp
       SOURCE_DIR  ${CMAKE_CURRENT_LIST_DIR}/external/http-link-header-cpp
+      GIT_REPOSITORY https://github.com/dcdpr/http-link-header-cpp.git
+      GIT_TAG origin/main
       INSTALL_DIR ${installDir}
       CMAKE_ARGS  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ cmake ..
 make
 ```
 
+You may run into permission issues during the build when the dependencies are
+being installed during the build step.  To install them in the project directory
+instead run cmake with the following command:
+
+```
+cmake .. "-DCMAKE_INSTALL_PREFIX=$(pwd)/install"
+```
+
 You can also run all the tests:
 
 ```

--- a/jsonld-cpp/Context.cpp
+++ b/jsonld-cpp/Context.cpp
@@ -70,7 +70,7 @@ namespace {
         // If term is @type, and processing mode is json-ld-1.0, a keyword redefinition error has
         // been detected and processing is aborted.
         if(term == JsonLdConsts::TYPE) {
-            if(activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if(activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 throw JsonLdError(JsonLdError::KeywordRedefinition, term);
             }
             // At this point, value MUST be a map with only either or both of the following entries:
@@ -161,7 +161,7 @@ namespace {
         // error has been detected and processing is aborted. If processing mode is json-ld-1.0, an
         // invalid term definition has been detected and processing is aborted.
         if (value.contains(JsonLdConsts::PROTECTED)) {
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 throw JsonLdError(JsonLdError::InvalidTermDefinition);
             }
 
@@ -192,7 +192,7 @@ namespace {
             // 12.3)
             // If the expanded type is @json or @none, and processing mode is json-ld-1.0, an invalid
             // type mapping error has been detected and processing is aborted.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 if(typeStr == JsonLdConsts::JSON || typeStr == JsonLdConsts::NONE) {
                     throw JsonLdError(JsonLdError::InvalidTypeMapping, type);
                 }
@@ -451,7 +451,7 @@ namespace {
             // If the container value is @graph, @id, or @type, or is otherwise not a string,
             // generate an invalid container mapping error and abort processing if processing
             // mode is json-ld-1.0.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 if (!container.is_string())
                     throw JsonLdError(JsonLdError::InvalidContainerMapping,
                                       "@container must be a string");
@@ -554,7 +554,7 @@ namespace {
             // 20.1)
             // If processing mode is json-ld-1.0 or container mapping does not include
             // @index, an invalid term definition has been detected and processing is aborted.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0) ||
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0) ||
                 !JsonLdUtils::containsOrEquals(definition[JsonLdConsts::CONTAINER], JsonLdConsts::INDEX)) {
                 throw JsonLdError(JsonLdError::InvalidTermDefinition,"");
             }
@@ -589,7 +589,7 @@ namespace {
             // 21.1)
             // If processing mode is json-ld-1.0, an invalid term definition has been detected
             // and processing is aborted.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 throw JsonLdError(JsonLdError::InvalidTermDefinition,"");
             }
 
@@ -673,7 +673,7 @@ namespace {
             // 24.1)
             // If processing mode is json-ld-1.0, an invalid term definition has been detected
             // and processing is aborted.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                 throw JsonLdError(JsonLdError::InvalidTermDefinition,"");
             }
 
@@ -704,7 +704,7 @@ namespace {
             // If processing mode is json-ld-1.0, or if term contains a colon (:) or
             // slash (/), an invalid term definition has been detected and processing
             // is aborted.
-            if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0) ||
+            if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0) ||
                 term.find(':') != std::string::npos ||
                 term.find('/') != std::string::npos) {
                 throw JsonLdError(JsonLdError::InvalidTermDefinition);
@@ -1166,7 +1166,7 @@ Context Context::process(const json & ilocalContext, const std::string & baseURL
             // 5.5.2)
             // If processing mode is set to json-ld-1.0, a processing mode conflict error
             // has been detected and processing is aborted.
-            if (isProcessingMode(JsonLdOptions::JSON_LD_1_0))
+            if (isProcessingMode(JsonLdConsts::JSON_LD_1_0))
                 throw JsonLdError(JsonLdError::ProcessingModeConflict);
         }
 
@@ -1176,7 +1176,7 @@ Context Context::process(const json & ilocalContext, const std::string & baseURL
             // 5.6.1)
             // If processing mode is json-ld-1.0, an invalid context entry error has
             // been detected and processing is aborted.
-            if (isProcessingMode(JsonLdOptions::JSON_LD_1_0))
+            if (isProcessingMode(JsonLdConsts::JSON_LD_1_0))
                 throw JsonLdError(JsonLdError::InvalidContextEntry);
 
             auto value = context.at(JsonLdConsts::IMPORT);
@@ -1346,7 +1346,7 @@ Context Context::process(const json & ilocalContext, const std::string & baseURL
             // 5.10.1)
             // If processing mode is json-ld-1.0, an invalid context entry error has been
             // detected and processing is aborted.
-            if (isProcessingMode(JsonLdOptions::JSON_LD_1_0))
+            if (isProcessingMode(JsonLdConsts::JSON_LD_1_0))
                 throw JsonLdError(JsonLdError::InvalidContextEntry);
             // 5.10.2)
             // Initialize value to the value associated with the @direction entry.
@@ -1377,7 +1377,7 @@ Context Context::process(const json & ilocalContext, const std::string & baseURL
         // 5.11)
         if (context.contains(JsonLdConsts::PROPAGATE)) {
             // 5.11.1)
-            if (isProcessingMode(JsonLdOptions::JSON_LD_1_0))
+            if (isProcessingMode(JsonLdConsts::JSON_LD_1_0))
                 throw JsonLdError(JsonLdError::InvalidContextEntry);
             // 5.11.2)
             if (!context.at(JsonLdConsts::PROPAGATE).is_boolean()) {

--- a/jsonld-cpp/ExpansionProcessor.cpp
+++ b/jsonld-cpp/ExpansionProcessor.cpp
@@ -377,7 +377,7 @@ namespace {
                 // (unless processing mode is json-ld-1.0), a colliding keywords error has been
                 // detected and processing is aborted.
                 if (result.contains(expandedProperty)) {
-                    if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+                    if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                         throw JsonLdError(JsonLdError::CollidingKeywords,
                                           expandedProperty + " already exists in result");
                     }
@@ -522,7 +522,7 @@ namespace {
                 else if (expandedProperty == JsonLdConsts::INCLUDED) {
                     // 13.4.6.1)
                     // If processing mode is json-ld-1.0, continue with the next key from element.
-                    if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+                    if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                         continue;
                     }
                     // 13.4.6.2)
@@ -569,7 +569,7 @@ namespace {
                     // is json-ld-1.0, an invalid value object value error has been detected and
                     // processing is aborted.
                     if(inputType == JsonLdConsts::JSON) {
-                        if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+                        if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                             throw JsonLdError(JsonLdError::InvalidValueObjectValue);
                         }
                         expandedValue = element_value;
@@ -635,7 +635,7 @@ namespace {
                 else if (expandedProperty == JsonLdConsts::DIRECTION) {
                     // 13.4.9.1)
                     // If processing mode is json-ld-1.0, continue with the next key from element.
-                    if (activeContext.isProcessingMode(JsonLdOptions::JSON_LD_1_0)) {
+                    if (activeContext.isProcessingMode(JsonLdConsts::JSON_LD_1_0)) {
                         continue;
                     }
                     // 13.4.9.2)

--- a/jsonld-cpp/JsonLdConsts.h
+++ b/jsonld-cpp/JsonLdConsts.h
@@ -72,6 +72,10 @@ namespace JsonLdConsts {
     static constexpr const char PREFIX[] = "@prefix";
     static constexpr const char INCLUDED[] = "@included";
 
+    static constexpr const char JSON_LD_1_0[] = "json-ld-1.0";
+    static constexpr const char JSON_LD_1_1[] = "json-ld-1.1";
+    static constexpr bool DEFAULT_COMPACT_ARRAYS = true;
+
     // various flags used for term definitions
     static constexpr const char IS_PREFIX_FLAG[] = "@flag.prefix";
     static constexpr const char IS_PROTECTED_FLAG[] = "@flag.protected";

--- a/jsonld-cpp/JsonLdOptions.cpp
+++ b/jsonld-cpp/JsonLdOptions.cpp
@@ -2,9 +2,9 @@
 
 
 // definitions needed here for static members (though not necessary in c++17)
-constexpr const char JsonLdOptions::JSON_LD_1_0[];
-constexpr const char JsonLdOptions::JSON_LD_1_1[];
-constexpr bool JsonLdOptions::DEFAULT_COMPACT_ARRAYS;
+//constexpr const char JsonLdOptions::JSON_LD_1_0[];
+//constexpr const char JsonLdOptions::JSON_LD_1_1[];
+//constexpr bool JsonLdOptions::DEFAULT_COMPACT_ARRAYS;
 
 bool JsonLdOptions::isFrameExpansion() const {
     return frameExpansion_;

--- a/jsonld-cpp/JsonLdOptions.h
+++ b/jsonld-cpp/JsonLdOptions.h
@@ -28,7 +28,7 @@ private:
      * if they have just one element.
      * https://www.w3.org/TR/json-ld-api/#dom-jsonldoptions-compactarrays
      */
-    bool compactArrays_ = DEFAULT_COMPACT_ARRAYS;
+    bool compactArrays_ = JsonLdConsts::DEFAULT_COMPACT_ARRAYS;
 
     /**
      * Determines if IRIs are compacted relative to the base option or document location
@@ -87,7 +87,7 @@ private:
      * json-ld as they are reserved for future versions of this specification.
      * https://www.w3.org/TR/json-ld-api/#dom-jsonldoptions-processingmode
      */
-    std::string processingMode_ = JSON_LD_1_1;
+    std::string processingMode_ = JsonLdConsts::JSON_LD_1_1;
 
     /**
      * If set to true, the JSON-LD processor may emit blank nodes for triple
@@ -146,11 +146,6 @@ private:
 
 public:
 
-    static constexpr const char JSON_LD_1_0[] = "json-ld-1.0";
-
-    static constexpr const char JSON_LD_1_1[] = "json-ld-1.1";
-
-    static constexpr bool DEFAULT_COMPACT_ARRAYS = true;
 
     /**
      * Constructs an instance of JsonLdOptions using the given base IRI. Defaults to
@@ -295,7 +290,7 @@ public:
 
     void setProcessingMode(const std::string& processingMode) {
         this->processingMode_ = processingMode;
-        if (processingMode == JSON_LD_1_1) {
+        if (processingMode == JsonLdConsts::JSON_LD_1_1) {
             omitGraph_ = true;
         }
     }


### PR DESCRIPTION
I ran into a couple of issues and managed to fix some of them (details below) in the pull request.

Issue:
-------
```
michael@localhost ~/github/jsonld-cpp/build $ cmake ..
-- ---------------- JSONLDCPP OPTIONS ----------------
-- JSONLDCPP_PROJECT : jsonld-cpp
-- JSONLDCPP_VERSION : 0.5.0
-- JSONLDCPP_BUILD_TESTS : ON
-- JSONLDCPP_BUILD_EXAMPLES : ON
-- INSTALL_JSONLDCPP : ON
-- CMAKE_BUILD_TYPE :
-- CMAKE_INSTALL_PREFIX :
-- CMAKE_TOOLCHAIN_FILE :

-- installDir : /home/michael/github/jsonld-cpp/build/install
-- The CXX compiler identification is GNU 11.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/share/cmake/Modules/ExternalProject.cmake:3114 (message):
No download info given for 'http-link-header-cpp' and its source directory:

 /home/michael/github/jsonld-cpp/external/http-link-header-cpp

is not an existing non-empty directory. Please specify one of:

 * SOURCE_DIR with an existing non-empty directory
 * DOWNLOAD_COMMAND
 * URL
 * GIT_REPOSITORY
 * SVN_REPOSITORY
 * HG_REPOSITORY
 * CVS_REPOSITORY and CVS_MODULE

Call Stack (most recent call first):
/usr/share/cmake/Modules/ExternalProject.cmake:4170 (_ep_add_download_command)
CMakeLists.txt:102 (ExternalProject_Add)
```
Resolution:
--------------
Add to jsonld-cpp/CMakeLists.txt:
```
ExternalProject_Add(http-link-header-cpp
SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/external/http-link-header-cpp
     GIT_REPOSITORY https://github.com/dcdpr/http-link-header-cpp.git
    INSTALL_DIR ${installDir}
    CMAKE_ARGS  -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
                -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
    DEPENDS     uriparser
    )
```
Issue:
--------
```
[100%] Linking CXX shared library ../lib/libcpr.so
[100%] Built target cpr
[ 17%] Performing install step for 'cpr'
Consolidate compiler generated dependencies of target zlib
[ 18%] Built target zlib
Consolidate compiler generated dependencies of target libcurl
[ 92%] Built target libcurl
Consolidate compiler generated dependencies of target cpr
[100%] Built target cpr
Install the project...
-- Install configuration: "Debug"
-- Installing: /usr/local/lib/libz.so.1.2.11.zlib-ng
CMake Error at _deps/zlib-build/cmake_install.cmake:65 (file):
file INSTALL cannot copy file
"/home/michael/github/jsonld-cpp/build/cpr-prefix/src/cpr-build/lib/libz.so.1.2.11.zlib-ng"
to "/usr/local/lib/libz.so.1.2.11.zlib-ng": Permission denied.
Call Stack (most recent call first):
cmake_install.cmake:47 (include)

make[3]: *** [Makefile100 install] Error 1
make[2]: *** [CMakeFiles/cpr.dir/build.make:103:
cpr-prefix/src/cpr-stamp/cpr-install] Error 2
make[1]: *** [CMakeFiles/Makefile2:92: CMakeFiles/cpr.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
Resolution:
---------------
Run cmake with redefinition of CMAKE_INSTALL_PREFIX:
```
cmake .. "-DCMAKE_INSTALL_PREFIX=$(pwd)/install"
```
Issue:
--------
```
fatal: invalid reference: master
CMake Error at
/home/michael/github/jsonld-cpp/build/http-link-header-cpp-prefix/tmp/http-link-header-cpp-gitclone.cmake:49
(message):
Failed to checkout tag: 'master'

make[2]: *** [CMakeFiles/http-link-header-cpp.dir/build.make:99:
http-link-header-cpp-prefix/src/http-link-header-cpp-stamp/http-link-header-cpp-download]
Error 1
make[1]: *** [CMakeFiles/Makefile2:144:
CMakeFiles/http-link-header-cpp.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
Resolution:
---------------
Add to jsonld-cpp/CmakeLists.txt:
```
ExternalProject_Add(http-link-header-cpp
SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/external/http-link-header-cpp
GIT_REPOSITORY https://github.com/dcdpr/http-link-header-cpp.git
GIT_TAG origin/main
INSTALL_DIR ${installDir}
CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
DEPENDS uriparser
)
```
issue:
--------
```
[ 95%] Performing build step for 'jsonld-cpp-examples'
[ 50%] Building CXX object CMakeFiles/jsonld2rdf.dir/jsonld2rdf.cpp.o
[100%] Linking CXX executable jsonld2rdf
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/../../../../x86_64-pc-linux-gnu/bin/ld:
/home/michael/github/jsonld-cpp/build/install/lib64/libjsonld-cpp.a(JsonLdOptions.cpp.o):(.rodata+0x728):
multiple definition of `JsonLdOptions::JSON_LD_1_1';
CMakeFiles/jsonld2rdf.dir/jsonld2rdf.cpp.o:(.rodata._ZN13JsonLdOptions11JSON_LD_1_1E[_ZN13JsonLdOptions11JSON_LD_1_1E]+0x0):
first defined here
collect2: error: ld returned 1 exit status
make[5]: *** [CMakeFiles/jsonld2rdf.dir/build.make:99: jsonld2rdf] Error 1
make[4]: *** [CMakeFiles/Makefile2:83: CMakeFiles/jsonld2rdf.dir/all] Error 2
make[3]: *** [Makefile:91: all] Error 2
make[2]: *** [CMakeFiles/jsonld-cpp-examples.dir/build.make:86:
jsonld-cpp-examples-prefix/src/jsonld-cpp-examples-stamp/jsonld-cpp-examples-build]
Error 2
make[1]: *** [CMakeFiles/Makefile2:198:
CMakeFiles/jsonld-cpp-examples.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
Resolution:
---------------
Moved definition of constants in JsonLdOptions to JsonLdConsts.h and changed references to them throughout