### PR TITLE
derive RDFQuad from RDFTriple to reduce duplicate code

### DIFF
--- a/jsonld-cpp/RDFQuad.cpp
+++ b/jsonld-cpp/RDFQuad.cpp
@@ -1,4 +1,5 @@
 #include "jsonld-cpp/RDFQuad.h"
+#include "jsonld-cpp/RDFTriple.h"
 #include "jsonld-cpp/DoubleFormatter.h"
 #include "jsonld-cpp/BlankNodeNames.h"
 #include "jsonld-cpp/NQuadsSerialization.h"
@@ -7,7 +8,118 @@ using nlohmann::json;
 
 namespace RDF {
 
-    bool operator!=(const RDF::RDFQuad &lhs, const RDF::RDFQuad &rhs) {
+    class RDFQuadImpl : private RDFTriple {
+    public:
+        RDFQuadImpl(std::shared_ptr<Node> &isubject, std::shared_ptr<Node> &ipredicate, std::shared_ptr<Node> &iobject)
+                : RDFTriple(isubject, ipredicate, iobject) {}
+
+        RDFQuadImpl(const std::string &isubject, const std::string &ipredicate, const std::string &iobject)
+                : RDFTriple(isubject, ipredicate, iobject) {}
+
+        explicit RDFQuadImpl(const RDFTriple &rhs) : RDFTriple(rhs) {}
+
+        explicit RDFQuadImpl(RDFTriple &&rhs) : RDFTriple(rhs) {}
+
+        std::shared_ptr<Node> getSubject() const override {
+            return RDFTriple::getSubject();
+        }
+
+        std::shared_ptr<Node> getPredicate() const override {
+            return RDFTriple::getPredicate();
+        }
+
+        std::shared_ptr<Node> getObject() const override {
+            return RDFTriple::getObject();
+        }
+
+    };
+
+    RDFQuad::RDFQuad(std::shared_ptr<Node> isubject, std::shared_ptr<Node> ipredicate, std::shared_ptr<Node> iobject,
+                     std::string *igraph)
+            : pimpl_(new RDFQuadImpl(isubject, ipredicate, iobject))
+    {
+        if (igraph != nullptr && *igraph != "@default") {
+            BlankNodeNames::hasFormOfBlankNodeName(*igraph) ?
+            setGraph(std::make_shared<BlankNode>(*igraph)) :
+            setGraph(std::make_shared<IRI>(*igraph));
+        }
+    }
+
+    RDFQuad::RDFQuad(const std::string& isubject, const std::string& ipredicate, const std::string& iobject, std::string *igraph)
+            : pimpl_(new RDFQuadImpl(isubject, ipredicate, iobject))
+    {
+        if (igraph != nullptr && *igraph != "@default") {
+            BlankNodeNames::hasFormOfBlankNodeName(*igraph) ?
+                setGraph(std::make_shared<BlankNode>(*igraph)) :
+                setGraph(std::make_shared<IRI>(*igraph));
+        }
+    }
+
+    std::shared_ptr<Node> RDFQuad::getSubject() const {
+        return pimpl_->getSubject();
+    }
+
+    std::shared_ptr<Node> RDFQuad::getPredicate() const {
+        return pimpl_->getPredicate();
+    }
+
+    std::shared_ptr<Node> RDFQuad::getObject() const {
+        return pimpl_->getObject();
+    }
+
+    std::shared_ptr<Node> RDFQuad::getGraph() const {
+        return graph;
+    }
+
+    std::string RDFQuad::toString() const {
+        return NQuadsSerialization::toNQuad(*this);
+    }
+
+    RDFQuad::RDFQuad(const RDFQuad &rhs) {
+        pimpl_ = rhs.pimpl_;
+
+        if(rhs.graph && rhs.graph->isBlankNode())
+            graph = std::make_shared<BlankNode>(rhs.graph->getValue());
+        else if(rhs.graph && rhs.graph->isIRI())
+            graph = std::make_shared<IRI>(rhs.graph->getValue());
+    }
+
+    RDFQuad::RDFQuad(RDFQuad&& rhs) noexcept {
+        pimpl_ = std::move(rhs.pimpl_);
+        graph = std::move(rhs.graph);
+    }
+
+    RDFQuad::~RDFQuad() {
+
+    }
+
+    RDFQuad & RDFQuad::operator=(const RDFQuad &rhs) {
+        if (&rhs != this) {
+            pimpl_ = rhs.pimpl_;
+            graph = std::shared_ptr<Node>{rhs.graph};
+        }
+        return *this;
+    }
+
+    RDFQuad& RDFQuad::operator= (RDFQuad&& rhs) noexcept {
+        if (&rhs != this) {
+            pimpl_ = std::move(rhs.pimpl_);
+            graph = std::shared_ptr<Node>{rhs.graph};
+            rhs.graph = nullptr;
+        }
+        return *this;
+    }
+
+    bool operator==(const RDFQuad &lhs, const RDFQuad &rhs) {
+        NodePtrEquals equals;
+        return
+                equals(lhs.getSubject(), rhs.getSubject()) &&
+                equals(lhs.getPredicate(), rhs.getPredicate()) &&
+                equals(lhs.getObject(), rhs.getObject()) &&
+                equals(lhs.getGraph(), rhs.getGraph());
+    }
+
+    bool operator!=(const RDFQuad &lhs, const RDFQuad &rhs) {
         return !(rhs == lhs);
     }
 
@@ -34,121 +146,6 @@ namespace RDF {
 
     bool operator>=(const RDFQuad &lhs, const RDFQuad &rhs) {
         return !(lhs < rhs);
-    }
-
-    RDFQuad::RDFQuad(std::shared_ptr<Node> isubject, std::shared_ptr<Node> ipredicate, std::shared_ptr<Node> iobject,
-                     std::string *igraph) {
-        setSubject(std::move(isubject));
-        setPredicate(std::move(ipredicate));
-        setObject(std::move(iobject));
-
-        if (igraph != nullptr && *igraph != "@default") {
-            BlankNodeNames::hasFormOfBlankNodeName(*igraph) ?
-            setGraph(std::make_shared<BlankNode>(*igraph)) :
-            setGraph(std::make_shared<IRI>(*igraph));
-        }
-    }
-
-    RDFQuad::RDFQuad(const std::string& isubject, const std::string& ipredicate, const std::string& iobject, std::string *igraph) {
-        BlankNodeNames::hasFormOfBlankNodeName(isubject) ?
-            setSubject(std::make_shared<BlankNode>(isubject)) :
-            setSubject(std::make_shared<IRI>(isubject));
-
-        setPredicate(std::make_shared<IRI>(ipredicate));
-
-        BlankNodeNames::hasFormOfBlankNodeName(iobject) ?
-            setObject(std::make_shared<BlankNode>(iobject)) :
-            setObject(std::make_shared<IRI>(iobject)); // todo: literal?
-
-        if (igraph != nullptr && *igraph != "@default") {
-            BlankNodeNames::hasFormOfBlankNodeName(*igraph) ?
-                setGraph(std::make_shared<BlankNode>(*igraph)) :
-                setGraph(std::make_shared<IRI>(*igraph));
-        }
-    }
-
-    std::shared_ptr<Node> RDFQuad::getSubject() const {
-        return subject;
-    }
-
-    std::shared_ptr<Node> RDFQuad::getPredicate() const {
-        return predicate;
-    }
-
-    std::shared_ptr<Node> RDFQuad::getObject() const {
-        return object;
-    }
-
-    std::shared_ptr<Node> RDFQuad::getGraph() const {
-        return graph;
-    }
-
-    std::string RDFQuad::toString() const {
-        return NQuadsSerialization::toNQuad(*this);
-    }
-
-    RDFQuad::RDFQuad(const RDFQuad &rhs) {
-        if(rhs.subject->isBlankNode())
-            subject = std::make_shared<BlankNode>(rhs.subject->getValue());
-        else if(rhs.subject->isIRI())
-            subject = std::make_shared<IRI>(rhs.subject->getValue());
-
-        predicate = std::make_shared<IRI>(rhs.predicate->getValue());
-
-        if(rhs.object->isBlankNode())
-            object = std::make_shared<BlankNode>(rhs.object->getValue());
-        else if(rhs.object->isIRI())
-            object = std::make_shared<IRI>(rhs.object->getValue());
-        else if (rhs.object->isLiteral()) {
-            std::string dataType = rhs.object->getDatatype();
-            std::string language = rhs.object->getLanguage();
-            object = std::make_shared<Literal>(rhs.object->getValue(), &dataType, &language);
-        }
-
-        if(rhs.graph && rhs.graph->isBlankNode())
-            graph = std::make_shared<BlankNode>(rhs.graph->getValue());
-        else if(rhs.graph && rhs.graph->isIRI())
-            graph = std::make_shared<IRI>(rhs.graph->getValue());
-    }
-
-    RDFQuad::RDFQuad(RDFQuad&& rhs) noexcept {
-        subject = std::move(rhs.subject);
-        predicate = std::move(rhs.predicate);
-        object = std::move(rhs.object);
-        graph = std::move(rhs.graph);
-    }
-
-    RDFQuad & RDFQuad::operator=(const RDFQuad &rhs) {
-        if (&rhs != this) {
-            subject = std::shared_ptr<Node>{rhs.subject};
-            predicate = std::shared_ptr<Node>{rhs.predicate};
-            object = std::shared_ptr<Node>{rhs.object};
-            graph = std::shared_ptr<Node>{rhs.graph};
-        }
-        return *this;
-    }
-
-    RDFQuad& RDFQuad::operator= (RDFQuad&& rhs) noexcept {
-        if (&rhs != this) {
-            subject = std::shared_ptr<Node>{rhs.subject};
-            predicate = std::shared_ptr<Node>{rhs.predicate};
-            object = std::shared_ptr<Node>{rhs.object};
-            graph = std::shared_ptr<Node>{rhs.graph};
-            rhs.subject = nullptr;
-            rhs.predicate = nullptr;
-            rhs.object = nullptr;
-            rhs.graph = nullptr;
-        }
-        return *this;
-    }
-
-    bool operator==(const RDFQuad &lhs, const RDFQuad &rhs) {
-        NodePtrEquals equals;
-        return
-                equals(lhs.getSubject(), rhs.getSubject()) &&
-                equals(lhs.getPredicate(), rhs.getPredicate()) &&
-                equals(lhs.getObject(), rhs.getObject()) &&
-                equals(lhs.getGraph(), rhs.getGraph());
     }
 
 }

--- a/jsonld-cpp/RDFQuad.h
+++ b/jsonld-cpp/RDFQuad.h
@@ -8,17 +8,14 @@
 
 namespace RDF {
 
+    class RDFQuadImpl;
+
     class RDFQuad {
     private:
+        std::shared_ptr<RDFQuadImpl> pimpl_;
 
-        std::shared_ptr<Node> subject;
-        std::shared_ptr<Node> predicate;
-        std::shared_ptr<Node> object;
         std::shared_ptr<Node> graph;
 
-        void setSubject(std::shared_ptr<Node> isubject) { subject = std::move(isubject); }
-        void setPredicate(std::shared_ptr<Node> ipredicate)  { predicate = std::move(ipredicate); }
-        void setObject(std::shared_ptr<Node> iobject)  { object = std::move(iobject); }
         void setGraph(std::shared_ptr<Node> igraph)  { graph = std::move(igraph); }
 
     public:
@@ -30,6 +27,8 @@ namespace RDF {
 
         RDFQuad(const RDFQuad &rhs);
         RDFQuad(RDFQuad&& rhs) noexcept;
+
+        virtual ~RDFQuad();
 
         RDFQuad& operator= (const RDFQuad &rhs);
         RDFQuad& operator= (RDFQuad&& rhs) noexcept;
@@ -45,8 +44,8 @@ namespace RDF {
 
     };
 
-    bool operator==(const RDF::RDFQuad &lhs, const RDF::RDFQuad &rhs);
-    bool operator!=(const RDF::RDFQuad &lhs, const RDF::RDFQuad &rhs);
+    bool operator==(const RDFQuad &lhs, const RDFQuad &rhs);
+    bool operator!=(const RDFQuad &lhs, const RDFQuad &rhs);
     bool operator<(const RDFQuad &lhs, const RDFQuad &rhs);
     bool operator>(const RDFQuad &lhs, const RDFQuad &rhs);
     bool operator<=(const RDFQuad &lhs, const RDFQuad &rhs);

--- a/jsonld-cpp/RDFSerializationProcessor.cpp
+++ b/jsonld-cpp/RDFSerializationProcessor.cpp
@@ -591,6 +591,7 @@ namespace {
         // from the description of the Deserialize JSON-LD to RDF algorithm.
         // See: https://www.w3.org/TR/json-ld11-api/#deserialize-json-ld-to-rdf-algorithm
 
+        // todo: remove?
         std::shared_ptr<Node> rdf_first = std::make_shared<IRI>(JsonLdConsts::RDF_FIRST);
         std::shared_ptr<Node> rdf_rest = std::make_shared<IRI>(JsonLdConsts::RDF_REST);
         std::shared_ptr<Node> rdf_nil = std::make_shared<IRI>(JsonLdConsts::RDF_NIL);

--- a/jsonld-cpp/RDFTriple.cpp
+++ b/jsonld-cpp/RDFTriple.cpp
@@ -7,33 +7,6 @@ using nlohmann::json;
 
 namespace RDF {
 
-    bool operator!=(const RDF::RDFTriple &lhs, const RDF::RDFTriple &rhs) {
-        return !(rhs == lhs);
-    }
-
-    bool operator<(const RDFTriple &lhs, const RDFTriple &rhs) {
-        NodePtrLess less;
-        NodePtrEquals equals;
-        if(!equals(lhs.getSubject(), rhs.getSubject()))
-            return less(lhs.getSubject(), rhs.getSubject());
-        if(!equals(lhs.getPredicate(), rhs.getPredicate()))
-            return less(lhs.getPredicate(), rhs.getPredicate());
-
-        return less(lhs.getObject(), rhs.getObject());
-    }
-
-    bool operator>(const RDFTriple &lhs, const RDFTriple &rhs) {
-        return rhs < lhs;
-    }
-
-    bool operator<=(const RDFTriple &lhs, const RDFTriple &rhs) {
-        return !(rhs < lhs);
-    }
-
-    bool operator>=(const RDFTriple &lhs, const RDFTriple &rhs) {
-        return !(lhs < rhs);
-    }
-
     RDFTriple::RDFTriple(std::shared_ptr<Node> isubject, std::shared_ptr<Node> ipredicate, std::shared_ptr<Node> iobject) {
         setSubject(std::move(isubject));
         setPredicate(std::move(ipredicate));
@@ -114,12 +87,39 @@ namespace RDF {
         return *this;
     }
 
-    bool operator==(const RDF::RDFTriple &lhs, const RDF::RDFTriple &rhs) {
+    bool operator==(const RDFTriple &lhs, const RDFTriple &rhs) {
         NodePtrEquals equals;
         return
                 equals(lhs.getSubject(), rhs.getSubject()) &&
                 equals(lhs.getPredicate(), rhs.getPredicate()) &&
                 equals(lhs.getObject(), rhs.getObject());
+    }
+
+    bool operator!=(const RDFTriple &lhs, const RDFTriple &rhs) {
+        return !(rhs == lhs);
+    }
+
+    bool operator<(const RDFTriple &lhs, const RDFTriple &rhs) {
+        NodePtrLess less;
+        NodePtrEquals equals;
+        if(!equals(lhs.getSubject(), rhs.getSubject()))
+            return less(lhs.getSubject(), rhs.getSubject());
+        if(!equals(lhs.getPredicate(), rhs.getPredicate()))
+            return less(lhs.getPredicate(), rhs.getPredicate());
+
+        return less(lhs.getObject(), rhs.getObject());
+    }
+
+    bool operator>(const RDFTriple &lhs, const RDFTriple &rhs) {
+        return rhs < lhs;
+    }
+
+    bool operator<=(const RDFTriple &lhs, const RDFTriple &rhs) {
+        return !(rhs < lhs);
+    }
+
+    bool operator>=(const RDFTriple &lhs, const RDFTriple &rhs) {
+        return !(lhs < rhs);
     }
 
 }

--- a/jsonld-cpp/RDFTriple.h
+++ b/jsonld-cpp/RDFTriple.h
@@ -10,11 +10,11 @@ namespace RDF {
 
     class RDFTriple {
     private:
-
         std::shared_ptr<Node> subject;
         std::shared_ptr<Node> predicate;
         std::shared_ptr<Node> object;
 
+    protected:
         void setSubject(std::shared_ptr<Node> isubject) { subject = std::move(isubject); }
         void setPredicate(std::shared_ptr<Node> ipredicate) { predicate = std::move(ipredicate); }
         void setObject(std::shared_ptr<Node> iobject) { object = std::move(iobject); }
@@ -31,9 +31,9 @@ namespace RDF {
         RDFTriple& operator= (const RDFTriple &rhs);
         RDFTriple& operator= (RDFTriple&& rhs) noexcept;
 
-        std::shared_ptr<Node> getPredicate() const;
-        std::shared_ptr<Node> getObject() const;
-        std::shared_ptr<Node> getSubject() const;
+        virtual std::shared_ptr<Node> getPredicate() const;
+        virtual std::shared_ptr<Node> getObject() const;
+        virtual std::shared_ptr<Node> getSubject() const;
 
         std::string toString() const;
 
@@ -41,8 +41,8 @@ namespace RDF {
 
     };
 
-    bool operator==(const RDF::RDFTriple &lhs, const RDF::RDFTriple &rhs);
-    bool operator!=(const RDF::RDFTriple &lhs, const RDF::RDFTriple &rhs);
+    bool operator==(const RDFTriple &lhs, const RDFTriple &rhs);
+    bool operator!=(const RDFTriple &lhs, const RDFTriple &rhs);
     bool operator<(const RDFTriple &lhs, const RDFTriple &rhs);
     bool operator>(const RDFTriple &lhs, const RDFTriple &rhs);
     bool operator<=(const RDFTriple &lhs, const RDFTriple &rhs);


### PR DESCRIPTION
Attempt to refactor RDFTriple and RDFQuad to have RDFQuad derive from RDFTriple so that we reduce the amount of duplicated code in the two classes. This is to deal with issue #10